### PR TITLE
Highlight the gitignore block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ header of the template.
 
 For example, this template might live at `community/DotNet/InforCRM.gitignore`:
 
-```
+```gitignore
 # gitignore template for InforCRM (formerly SalesLogix)
 # website: https://www.infor.com/product-summary/cx/infor-crm/
 #


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

There is syntax highlighting support for gitignore code blocks (see below). We should make use of it to improve the readability of the documentation.

**Links to documentation supporting these rule changes:**

https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L2827